### PR TITLE
Revert "Update env table looks"

### DIFF
--- a/src/library/utils/env_vars.rs
+++ b/src/library/utils/env_vars.rs
@@ -29,7 +29,7 @@ pub async fn print_variables_box<S: ::std::hash::BuildHasher>(
     let source_margin = "─".to_string().repeat(longest_source_len);
 
     // Using longer | character for sides: │
-    logging::print_color(logging::NC, &format!("╭─{key_margin}─┬─{source_margin}─╮")).await;
+    logging::print_color(logging::NC, &format!("┌─{key_margin}─┬─{source_margin}─┐")).await;
     logging::print_color(
         logging::NC,
         &format!(
@@ -71,7 +71,7 @@ pub async fn print_variables_box<S: ::std::hash::BuildHasher>(
         logging::print_color(logging::NC, &format!("│ {parsed_key} │ {parsed_source} │")).await;
     }
 
-    logging::print_color(logging::NC, &format!("╰─{key_margin}─┴─{source_margin}─╯")).await;
+    logging::print_color(logging::NC, &format!("└─{key_margin}─┴─{source_margin}─┘")).await;
 }
 
 pub fn set(env_vars: &Vec<(String, String, String)>) {


### PR DESCRIPTION
The characters introduced in e5cd729 are not supported by a lot of fonts. Reverting back this update.

This reverts commit e5cd729336de5bf2050ef5eb57f65405c4be1b98.